### PR TITLE
Display toast errors when clearance or personnel search fails.

### DIFF
--- a/src/hooks/useClearance.js
+++ b/src/hooks/useClearance.js
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react'
+import { toaster } from 'evergreen-ui'
 import clearanceService from '../apis/clearanceService'
 
 const useClearance = (initialQuery = '') => {
-  const [getClearances, { data: clearances = [] }] =
+  const [getClearances, { data: clearances = [], isError }] =
     clearanceService.useLazyGetClearancesQuery()
 
   const [query, setQuery] = useState(initialQuery)
@@ -23,6 +24,12 @@ const useClearance = (initialQuery = '') => {
       }
     }
   }, [query])
+
+  useEffect(() => {
+    if (isError) {
+      toaster.danger('There was an error querying for clearances.')
+    }
+  }, [isError])
 
   return {
     clearances: query.length >= 3 ? clearances : [],

--- a/src/hooks/usePersonnel.js
+++ b/src/hooks/usePersonnel.js
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
+import { toaster } from 'evergreen-ui'
 import clearanceService from '../apis/clearanceService'
 
 const usePersonnel = (initialQuery = '') => {
-  const [getPersonnel, { data: personnel = [] }] =
+  const [getPersonnel, { data: personnel = [], isError }] =
     clearanceService.useLazyGetPersonnelQuery()
 
   const [query, setQuery] = useState(initialQuery)
@@ -23,6 +24,12 @@ const usePersonnel = (initialQuery = '') => {
       }
     }
   }, [query])
+
+  useEffect(() => {
+    if (isError) {
+      toaster.danger('There was an error querying for personnel.')
+    }
+  }, [isError])
 
   return {
     personnel: query.length >= 3 ? personnel : [],


### PR DESCRIPTION
## Changes

A generic toast error is displayed whenever a clearance or personnel search fails.

<img width="1047" alt="Screenshot 2023-03-01 at 1 03 29 PM" src="https://user-images.githubusercontent.com/10892225/222224443-598dd777-e15b-43d4-bad4-eafdb24c8cb2.png">

## How was this tested?

Tested manually in the browser.

## How were these changes documented?

No doc changes needed.

## Notes to reviewer

None
