### PR TITLE
Prevent error from appearing on canceled request

### DIFF
--- a/src/apis/clearanceService.js
+++ b/src/apis/clearanceService.js
@@ -13,7 +13,10 @@ const api = createApi({
         },
       }),
       transformResponse: (response, meta, args) => {
-        return response['clearance_names']
+        return {
+          clearances: response['clearance_names'],
+          length: response['clearance_names'].length,
+        }
       },
     }),
     getPersonnel: builder.query({
@@ -25,7 +28,10 @@ const api = createApi({
         },
       }),
       transformResponse: (response) => {
-        return response['personnel']
+        return {
+          personnel: response['personnel'],
+          length: response['personnel'].length,
+        }
       },
     }),
     getAssignments: builder.query({

--- a/src/hooks/usePersonnel.js
+++ b/src/hooks/usePersonnel.js
@@ -3,17 +3,27 @@ import { toaster } from 'evergreen-ui'
 import clearanceService from '../apis/clearanceService'
 
 const usePersonnel = (initialQuery = '') => {
-  const [getPersonnel, { data: personnel = [], isError, error }] =
-    clearanceService.useLazyGetPersonnelQuery()
+  const [
+    getPersonnel,
+    { data = { personnel: [], length: null }, isError, error, isLoading },
+  ] = clearanceService.useLazyGetPersonnelQuery()
 
   const [query, setQuery] = useState(initialQuery)
+  const [isTyping, setIsTyping] = useState(false)
 
   useEffect(() => {
     if (query.length >= 3) {
+      setIsTyping(true)
+
       let request
 
       const timeout = setTimeout(async () => {
+        setIsTyping(false)
         request = getPersonnel({ search: query })
+        request
+          .unwrap()
+          .then((payload) => setResultLength(payload.length))
+          .catch(() => {})
       }, 500)
 
       return () => {
@@ -22,6 +32,8 @@ const usePersonnel = (initialQuery = '') => {
         }
         clearTimeout(timeout)
       }
+    } else {
+      setIsTyping(false)
     }
   }, [query])
 
@@ -32,9 +44,12 @@ const usePersonnel = (initialQuery = '') => {
   }, [isError, error])
 
   return {
-    personnel: query.length >= 3 ? personnel : [],
+    personnel: query.length >= 3 ? data.personnel : [],
     personnelQuery: query,
     setPersonnelQuery: setQuery,
+    length: data.length,
+    isTyping,
+    isLoading,
   }
 }
 

--- a/src/pages/Assign.jsx
+++ b/src/pages/Assign.jsx
@@ -1,4 +1,5 @@
 import {
+  Pane,
   Heading,
   minorScale,
   TagInput,
@@ -7,6 +8,7 @@ import {
   toaster,
 } from 'evergreen-ui'
 import { useMemo, useState, useEffect } from 'react'
+import styled from 'styled-components'
 import ContentCard from '../components/ContentCard'
 import Layout from '../components/Layout'
 
@@ -15,15 +17,38 @@ import usePersonnel from '../hooks/usePersonnel'
 
 import clearanceService from '../apis/clearanceService'
 
+const NoResultsText = styled(Pane)`
+  display: ${({ $visible }) => ($visible ? 'block' : 'none')};
+  position: absolute;
+  bottom: 4px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #cccccc;
+  font-size: 0.8rem;
+`
+
 export default function AssignClearance() {
   const [assignClearance, { isLoading, isSuccess, isError, data }] =
     clearanceService.useAssignClearancesMutation()
 
   const [selectedClearances, setSelectedClearances] = useState([])
-  const { clearances, setClearanceQuery } = useClearance()
+  const {
+    clearances,
+    setClearanceQuery,
+    length: clearancesLength,
+    isTyping: isTypingClearances,
+    isLoading: isLoadingClearances,
+  } = useClearance()
 
   const [selectedPersonnel, setSelectedPersonnel] = useState([])
-  const { personnel, setPersonnelQuery } = usePersonnel()
+  const {
+    personnel,
+    setPersonnelQuery,
+    length: personnelLength,
+    isTyping: isTypingPersonnel,
+    isLoading: isLoadingPersonnel,
+  } = usePersonnel()
 
   // const [startDate, setStartDate] = useState(null)
   // const [endDate, setEndDate] = useState(null)
@@ -102,6 +127,13 @@ export default function AssignClearance() {
           onInputChange={(e) => setPersonnelQuery(e.target.value)}
           test-id='personnel-input'
         />
+        <NoResultsText
+          $visible={
+            !isLoadingPersonnel && !isTypingPersonnel && personnelLength === 0
+          }
+        >
+          No Personnel Found
+        </NoResultsText>
       </ContentCard>
 
       <ContentCard>
@@ -128,6 +160,15 @@ export default function AssignClearance() {
           onInputChange={(e) => setClearanceQuery(e.target.value)}
           test-id='clearance-input'
         />
+        <NoResultsText
+          $visible={
+            !isLoadingClearances &&
+            !isTypingClearances &&
+            clearancesLength === 0
+          }
+        >
+          No Clearances Found
+        </NoResultsText>
       </ContentCard>
 
       {/* <ContentCard>


### PR DESCRIPTION
## Changes

For requests for clearances or personnel, if the request was canceled, an error would appear. In these cases, errors will not appear.

## How was this tested?

Tested manually in the browser.

## How were these changes documented?

No doc changes needed.

## Notes to reviewer

None
