### PR TITLE
Focus Date Picker Once Timeframe Start or End is Selected

### DIFF
--- a/src/components/Timeframe.jsx
+++ b/src/components/Timeframe.jsx
@@ -163,6 +163,7 @@ export default function Timeframe({
             timeIntervals={15}
             timeFormat='h:mm aa'
             dateFormat='MM-dd-yyyy h:mm aa'
+            autoFocus
           />
         )}
       </LeftDateText>
@@ -176,6 +177,7 @@ export default function Timeframe({
             timeIntervals={15}
             timeFormat='h:mm aa'
             dateFormat='MM-dd-yyyy h:mm aa'
+            autoFocus
           />
         )}
       </RightDateText>


### PR DESCRIPTION
## Changes

The ability to change the timeframe start and end times has been made more prominent. When the start or end bubble is clicked, the date picker will appear automatically instead of having to click on the text string.

https://user-images.githubusercontent.com/10892225/229129518-f7373a2d-6f28-4786-aba2-c124212bf0c7.mov

## How was this tested?

Tested manually in the browser.

## How were these changes documented?

N/A

## Notes to reviewer

N/A
