### PR TITLE
Bug Fix: Assign Clearances to Multiple Users

### DIFF
--- a/src/pages/Manage.jsx
+++ b/src/pages/Manage.jsx
@@ -111,7 +111,7 @@ export default function ManageClearance() {
 
   // Fetch clearance assignments for the selected person.
   useEffect(() => {
-    if (selectedPersonnel.length > 0) {
+    if (selectedPersonnel.length === 1) {
       const campusId = selectedPersonnel[0]['campus_id']
 
       const request = getAssignments({ campusId: campusId })
@@ -288,7 +288,14 @@ export default function ManageClearance() {
               </Table.TextHeaderCell>
             </Table.Head>
             <Table.Body>
-              {isFetchingAssignments ? (
+              {selectedPersonnel.length > 1 ? (
+                <Pane className='center' padding={minorScale(6)}>
+                  <Text>
+                    Clearances cannot be shown when more than one person is
+                    selected.
+                  </Text>
+                </Pane>
+              ) : isFetchingAssignments ? (
                 <Pane className='center' padding={minorScale(6)}>
                   <Spinner size={majorScale(4)} marginX='auto' />
                 </Pane>


### PR DESCRIPTION
## Changes

- Multiple person selection has been fixed. Multiple persons can be assigned multiple clearances again.
- If multiple persons are selected, the table showing clearances will not show any clearance assignments.

<img width="702" alt="Screenshot 2023-04-03 at 11 44 00 AM" src="https://user-images.githubusercontent.com/10892225/229560862-a1f2b620-fd6c-46c5-b5ad-8c813ebc2a91.png">

## How was this tested?

Tested manually in the browser. All end-to-end tests continue to pass.

## How were these changes documented?

N/A

## Notes to reviewer

N/A
