### PR TITLE
Import Toaster Component from Evergreen

### DIFF
--- a/src/pages/Audit.jsx
+++ b/src/pages/Audit.jsx
@@ -14,6 +14,7 @@ import {
   Spinner,
   majorScale,
   minorScale,
+  toaster,
 } from 'evergreen-ui'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import clearanceService from '../apis/clearanceService'


### PR DESCRIPTION
## Changes

A bug has been fixed that crashed the application if an error occurred inside the Audit Log page. The issue was caused because the toaster component from Evergreen UI was used in the component but not imported. The bug was fixed by importing the component.

## How was this tested?

Tested manually in the browser.

## How were these changes documented?

N/A

## Notes to reviewer

N/A
