### PR TITLE
Add a Bottom Margin

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -57,6 +57,7 @@ const BodyContainer = styled(Pane)`
   margin-left: ${({ $isHidden, $isSidebarOpen }) =>
     $isHidden ? '0' : $isSidebarOpen ? '36px' : '8px'};
   margin-right: ${({ $isHidden }) => ($isHidden ? '0' : '8px')};
+  margin-bottom: ${({ $isHidden }) => ($isHidden ? '0' : '100px')};
 `
 
 export default function Layout({ sidebarContent, hideApp, children }) {


### PR DESCRIPTION
## Changes

A margin has been added to the bottom of each page. This was done specifically for the Audit Log so the content wouldn't hug the screen.

<img width="1266" alt="Screenshot 2023-04-10 at 3 55 47 PM" src="https://user-images.githubusercontent.com/10892225/230986200-4e2cdf26-9d23-474d-9dca-5ce7a66a5ad0.png">

## How was this tested?

Tested manually in the browser.

## How were these changes documented?

N/A

## Notes to reviewer

N/A
