### PR TITLE
Disable Revoke Buttons if No Permission to Revoke

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -37,6 +37,12 @@ const myTheme = mergeTheme(defaultTheme, {
           background: 'none',
           border: '1px solid #cc0000',
           color: '#cc0000',
+          selectors: {
+            _disabled: {
+              color: '#cccccc',
+              borderColor: '#cccccc',
+            },
+          },
         },
         minimal: {
           _hover: {

--- a/src/pages/Manage.jsx
+++ b/src/pages/Manage.jsx
@@ -7,8 +7,10 @@ import {
   Text,
   Spinner,
   Pane,
+  Tooltip,
   toaster,
   majorScale,
+  Position,
 } from 'evergreen-ui'
 import { useMemo, useState, useEffect, Fragment } from 'react'
 import clearanceService from '../apis/clearanceService'
@@ -159,7 +161,10 @@ export default function ManageClearance() {
       .then(() => {
         setClearanceAssignments((prev) => {
           const oldValues = JSON.parse(JSON.stringify(prev))
-          const newValues = JSON.parse(JSON.stringify(selectedClearances))
+          const newValues = selectedClearances.map((cl) => ({
+            ...cl,
+            can_revoke: true,
+          }))
 
           const clearanceIDs = {}
           const newClearances = []
@@ -310,20 +315,32 @@ export default function ManageClearance() {
                       .toLowerCase()
                       .includes(tableFilter.toLowerCase())
                   })
+                  .sort((a, b) => (a['name'] > b['name'] ? 1 : -1))
                   .map((cl) => (
                     <Table.Row key={cl['id']}>
                       <Table.TextCell flexBasis='65%'>
                         {cl['name']}
                       </Table.TextCell>
                       <Table.TextCell flexShrink={0} textAlign='right'>
-                        <Button
-                          test-id='revoke-clearance-btn'
-                          appearance='secondary'
-                          onClick={() => onRevokeClearance(cl['id'])}
-                          isLoading={loadingRevokeRequests.includes(cl['id'])}
+                        <Tooltip
+                          isShown={cl['can_revoke'] ? false : undefined}
+                          content='You do not have permission to revoke this clearance.'
+                          position={Position.RIGHT}
                         >
-                          Revoke
-                        </Button>
+                          <div>
+                            <Button
+                              test-id='revoke-clearance-btn'
+                              appearance='secondary'
+                              disabled={!cl['can_revoke']}
+                              onClick={() => onRevokeClearance(cl['id'])}
+                              isLoading={loadingRevokeRequests.includes(
+                                cl['id']
+                              )}
+                            >
+                              Revoke
+                            </Button>
+                          </div>
+                        </Tooltip>
                       </Table.TextCell>
                     </Table.Row>
                   ))


### PR DESCRIPTION
## Changes

Liaisons will not be able to revoke a clearance which they are not allowed to assign - the revoke button will be disabled. They will still be able to see the full list of clearances, however.

<img width="1563" alt="Screenshot 2023-04-11 at 12 30 21 PM" src="https://user-images.githubusercontent.com/10892225/231260530-6b97a361-9e05-45b6-8115-9f4b89bf17f7.png">

## How was this tested?

Tested manually in the browser.

## How were these changes documented?

No changes are needed in the documentation.

## Notes to reviewer

This change relies on a change in this pull request: https://github.com/ncstate-sat/clearance-service/pull/11
Do not merge this PR unless the above pull request is merged in.
